### PR TITLE
Guess the listening address family in UDP input

### DIFF
--- a/lib/logstash/inputs/gelf.rb
+++ b/lib/logstash/inputs/gelf.rb
@@ -180,7 +180,8 @@ class LogStash::Inputs::Gelf < LogStash::Inputs::Base
   def udp_listener(output_queue)
     @logger.info("Starting gelf listener (udp) ...", :address => "#{@host}:#{@port_udp}")
 
-    @udp = UDPSocket.new(Socket::AF_INET)
+    address_family, _, _ = Socket.getaddrinfo(@host, @port_udp)[0]
+    @udp = UDPSocket.new(Socket.const_get(address_family))
     @udp.bind(@host, @port_udp)
 
     while !stop?


### PR DESCRIPTION
This code path used to break for IPv6 addresses with
`SocketError (getaddrinfo: Address family for hostname not supported)`
because it was using `Socket::AF_INET` for every input.

This is related to a JRuby bug[1] that is marked as `wontfix`.

With the new implementation the address family is being retrieved by
`Socket.getaddrinfo` and supports both IPv4 and IPv6 addresses.

[1]: https://github.com/jruby/jruby/issues/5112

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
